### PR TITLE
Add pre-entry script to manage entrypoint wrapper

### DIFF
--- a/dockci.Dockerfile
+++ b/dockci.Dockerfile
@@ -21,6 +21,7 @@ ADD util/wheelhouse /code/wheelhouse
 ADD _deps_python.sh /code/_deps_python.sh
 RUN ./_deps_python.sh
 
+ADD entrypoint.sh /code/entrypoint.sh
 ADD manage.py /code/manage.py
 ADD dockci /code/dockci
 ADD tests /code/tests
@@ -28,5 +29,5 @@ ADD pylint.conf /code/pylint.conf
 ADD alembic /code/alembic
 
 EXPOSE 5000
-ENTRYPOINT ["/code/python_env/bin/python" , "/code/manage.py"]
+ENTRYPOINT ["/code/entrypoint.sh"]
 CMD ["run"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e
+
+THIS_DIR="$(cd "$(dirname "$0")"; pwd)"
+source "$THIS_DIR/python_env/bin/activate"
+
+if [[ -x "$THIS_DIR/pre-entry.sh" ]]; then
+  echo "Sourcing pre-entry script" >&2
+  source "$THIS_DIR/pre-entry.sh"
+else
+  echo "Skipping pre-entry script" >&2
+fi
+
+python "$THIS_DIR/manage.py" "$@"


### PR DESCRIPTION
Allow actions to be taken before management script is run.

This is necessary for #360 so that when the server is run, the DB can be cloned.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/sprucedev/dockci/361)
<!-- Reviewable:end -->
