### PR TITLE
Allow user API lookup with more than user ID

### DIFF
--- a/dockci/api/user.py
+++ b/dockci/api/user.py
@@ -250,7 +250,7 @@ for endpoint_suffix, url_suffix, klass_user, klass_me in (
     ('role_detail', '/roles/<string:role_name>', UserRoleDetail, MeRoleDetail),
 ):
     API.add_resource(klass_user,
-                     '/users/<int:user_id>%s' % url_suffix,
+                     '/users/<user_id>%s' % url_suffix,
                      'user_%s' % endpoint_suffix)
     API.add_resource(klass_me,
                      '/me%s' % url_suffix,


### PR DESCRIPTION
Int requirement in routing made it impossible to lookup user via email, however this is the expected way to lookup users.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sprucedev/dockci/478)
<!-- Reviewable:end -->
