### PR TITLE
Ignore existing model on API conflict checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Admin role protection for config #473
 - Fix user emails list output #474
 - Roles in user API #475, #477
+- API conflict checks don't apply to model being saved #479
 
 ### v0.0.10
 - Allow override of repo name in `dockci.yaml` #397

--- a/dockci/api/base.py
+++ b/dockci/api/base.py
@@ -31,12 +31,14 @@ class BaseDetailResource(Resource):
             for name, value in args.items()
             if name in unique_columns
         }
+
         conflicts = {
             field_name: "Duplicate value '%s'" % getattr(
                 query.first(), field_name,
             )
             for field_name, query in unique_model_conflicts(
                 model.__class__,
+                ignored_id=model.id,
                 **conflict_checks
             ).items()
         }

--- a/dockci/util.py
+++ b/dockci/util.py
@@ -660,12 +660,19 @@ def add_to_url_path(url, more_path):
     return urlunparse(url)
 
 
-def unique_model_conflicts(klass, **fields):
+def unique_model_conflicts(klass, ignored_id=None, **fields):
     """ Find any models that have values in fields """
     queries = {
         field_name: klass.query.filter_by(**{field_name: field_value})
         for field_name, field_value in fields.items()
     }
+
+    if ignored_id is not None:
+        queries = {
+            field_name: query.filter(klass.id != ignored_id)
+            for field_name, query in queries.items()
+        }
+
     return {
         field_name: query
         for field_name, query in queries.items()


### PR DESCRIPTION
Fixes a bug where you couldn't save an existing user with it's full JSON because `email` would conflict with itself

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sprucedev/dockci/479)
<!-- Reviewable:end -->
